### PR TITLE
Update User-Agent to current version

### DIFF
--- a/src/edge-tts.ts
+++ b/src/edge-tts.ts
@@ -60,7 +60,7 @@ class EdgeTTS {
       host: 'speech.platform.bing.com',
       origin: 'chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold',
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.66 Safari/537.36 Edg/103.0.1264.44',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0',
       },
       agent: this.proxy ? new HttpsProxyAgent(this.proxy) : undefined
     })


### PR DESCRIPTION
Update User-Agent to the latest version of Microsoft Edge browser to reduce the possibility of blocking by Microsoft, when actively using the old User-Agent by all `node-edge-tts` users.