### PR TITLE
add wsConnect error event

### DIFF
--- a/src/edge-tts.ts
+++ b/src/edge-tts.ts
@@ -65,7 +65,7 @@ class EdgeTTS {
       },
       agent: this.proxy ? new HttpsProxyAgent(this.proxy) : undefined
     })
-    return new Promise((resolve: Function) => {
+    return new Promise((resolve: Function, reject: Function) => {
       wsConnect.on('open', () => {
         wsConnect.send(`Content-Type:application/json; charset=utf-8\r\nPath:speech.config\r\n\r\n
           {
@@ -83,6 +83,9 @@ class EdgeTTS {
           }
         `)
         resolve(wsConnect)
+      })
+      wsConnect.on('error', (err) => {
+        reject(err)
       })
     })
   }


### PR DESCRIPTION
If this exception is not handled, it will cause the program to crash in concurrent scenarios.

Error: Unexpected server response: 503
    at ClientRequest.<anonymous> (file:///xxxx/dist/api.js?t=1743120569184:9278:7)
    at ClientRequest.emit (node:events:518:28)
    at HTTPParser.parserOnIncomingClient (node:_http_client:716:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
    at TLSSocket.socketOnData (node:_http_client:558:22)
    at TLSSocket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:189:23)