### PR TITLE
Add streamAudio method for real-time audio streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ const tts = new EdgeTTS()
 await tts.ttsPromise('Hello world', path_to_audiofile_with_extension)
 ```
 
+### streamAudio (streaming / SSE)
+
+**`streamAudio(text)`** returns an async generator (`AsyncGenerator<Buffer>`) that yields each binary audio chunk as it is received from the WebSocket — no file is written; suitable for SSE or real-time streaming.
+
+- **Stream end**: when the server sends `Path:turn.end`, when `timeout` (set in the constructor) is reached, or when the WebSocket errors.
+- **Chunk format**: each chunk is a `Buffer` (the audio payload after the `Path:audio\r\n` header in the binary message).
+
+Example with `for await`:
+
+```js
+const tts = new EdgeTTS({ voice: 'en-US-AriaNeural', lang: 'en-US' })
+
+for await (const chunk of tts.streamAudio('Hello world')) {
+  // Send chunk via SSE (e.g. event speech.audio.delta) or pipe to response
+  process.stdout.write(chunk)
+}
+```
+
 ### configure
 ```
 const tts = new EdgeTTS({


### PR DESCRIPTION
# Add `streamAudio()` for SSE / real-time streaming

## Summary

This PR adds a new method **`streamAudio(text)`** that streams TTS audio as it is received from the Edge WebSocket, without writing to a file. It is intended for servers that need to send audio over SSE (e.g. `speech.audio.delta` / `speech.audio.done`) or other real-time streaming use cases.

## What changed

- **New API**: `streamAudio(text: string): AsyncGenerator<Buffer>`
  - Async generator that yields each binary audio chunk when the WebSocket receives it.
  - Stream ends when: `Path:turn.end` is received, constructor `timeout` is reached, or the WebSocket errors.
  - Chunk format: raw audio `Buffer` (payload after `Path:audio\r\n` in the binary message).

- **Existing behavior**: `ttsPromise(text, audioPath)` is unchanged and still writes to a file.

- **Docs**: README updated with a "streamAudio (streaming / SSE)" section: usage, chunk format, and example with `for await`.

## Why

- **Use case**: Backends that need to stream TTS to the client in real time (e.g. OpenAI-compatible `stream_format: "sse"`) can consume `streamAudio()` and forward chunks as SSE events instead of buffering and then sending a file.
- **Compatibility**: No breaking changes; existing `ttsPromise` usage stays the same.

## Example

```js
const tts = new EdgeTTS({ voice: 'en-US-AriaNeural', lang: 'en-US' })

for await (const chunk of tts.streamAudio('Hello world')) {
  process.stdout.write(chunk)  // or send via SSE
}
```
---